### PR TITLE
Bump @glorious/demo to 0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,20 @@
   "requires": true,
   "dependencies": {
     "@glorious/demo": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@glorious/demo/-/demo-0.9.0.tgz",
+      "integrity": "sha512-2w8xlrEgC02XoQtszV0LSkSWj15Sn+H7oRcy7uHlH757R9qze4eOHIQlWSAQnz7wcoCCEsteB9kGWeoX9IS2pw==",
+      "requires": {
+        "@glorious/fyzer": "^0.1.0"
+      }
+    },
+    "@glorious/fyzer": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@glorious/demo/-/demo-0.1.0.tgz",
-      "integrity": "sha512-1nXeGo0TSAN3pwGp36PtblbQxhshOj0TfUSXVkyBEqX7VtLavdDF4JUC9FsGYWmd0RRwnNIZxONlbxrJ7FIoLg=="
+      "resolved": "https://registry.npmjs.org/@glorious/fyzer/-/fyzer-0.1.0.tgz",
+      "integrity": "sha512-knEJenhsa7TQLz6UZZbINYgFSRaaMV0beNbmmDjKnJZ+WQOvshDJbTbRfwv4TU8aGLBBjBa48aq++vtUOLoOZA==",
+      "requires": {
+        "shortid": "^2.2.15"
+      }
     },
     "@types/node": {
       "version": "8.10.30",
@@ -738,6 +749,11 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
     },
+    "nanoid": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+    },
     "node-json-db": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/node-json-db/-/node-json-db-1.0.3.tgz",
@@ -1040,6 +1056,14 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
       "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
       "dev": true
+    },
+    "shortid": {
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
+      "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
+      "requires": {
+        "nanoid": "^2.1.0"
+      }
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "electron": "^3.0.2"
   },
   "dependencies": {
-    "@glorious/demo": "^0.1.0",
+    "@glorious/demo": "^0.9.0",
     "fs": "^0.0.1-security",
-    "js-yaml": "^3.13.1",
-    "node-json-db": "^1.0.3",
     "fuse.js": "^3.4.6",
     "hotkeys-js": "^3.7.3",
+    "js-yaml": "^3.13.1",
+    "node-json-db": "^1.0.3",
     "prismjs": "^1.19.0"
   }
 }


### PR DESCRIPTION
As commented on https://github.com/glorious-codes/glorious-demo/issues/63, code written on editor was not highlighted. Bumping `@glorious/demo` version to 0.9.0 seems to solve the issue:

![2020-02-11 13 35 48](https://user-images.githubusercontent.com/4738687/74257695-f591b980-4cd3-11ea-9f11-ab191278c5d6.gif)
